### PR TITLE
Sorta needed a shebang for this, even though I expressly say to execu…

### DIFF
--- a/eagle_review.py
+++ b/eagle_review.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 import csv
 import sys
 from datetime import datetime


### PR DESCRIPTION
…te as "python3 foo.py"